### PR TITLE
Fix: typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install .
 ```
 
 ## Getting Started <a name="Getting Started"></a>
-Please see the [documentation](https:docs.openquantumdesign.org) for tutorials, examples, and API reference.
+Please see the [documentation](https://docs.openquantumdesign.org) for tutorials, examples, and API reference.
 Below is a simple example of an analog quantum program, in which a single qubit evolves under 
 a $\sigma_X$ Hamiltonian for 10 units of time and is then measured.
 ```python


### PR DESCRIPTION
Link started with `https:docs.` instead of `https://docs`, so it led to a 404 page.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
Link from readme leads to https://github.com/OpenQuantumDesign/oqd-core/blob/main/docs.openquantumdesign.org


* **What is the new behavior (if this is a feature change)?**
Link from readme leads to https://docs.openquantumdesign.org/

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
