### PR TITLE
Isinglike

### DIFF
--- a/src/oqd_core/__init__.py
+++ b/src/oqd_core/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import backend, compiler, interface
+from . import analysis, backend, compiler, interface
 
-__all__ = ["interface", "compiler", "backend"]
+__all__ = ["analysis", "backend", "compiler", "interface"]

--- a/src/oqd_core/analysis/__init__.py
+++ b/src/oqd_core/analysis/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/oqd_core/analysis/isinglike.py
+++ b/src/oqd_core/analysis/isinglike.py
@@ -252,7 +252,7 @@ def _traverse(operator: OperatorSubtypes) -> list[_PauliStringTerm]:
             return products
 
     traverser = Post(_PauliStringTermAccumulator())
-    return traverser(operator)
+    return traverser(operator)  # type: ignore
 
 
 def _are_all_pauli_strings_the_same_length(strings: list[_PauliStringTerm]) -> bool:
@@ -287,7 +287,7 @@ def _has_bosonic_operator(op: OperatorSubtypes) -> bool:
             return operands["op"]
 
     traverser = Post(_BosonicOperatorFinder())
-    return traverser(op)
+    return traverser(op)  # type: ignore
 
 
 def _has_mathvar(expr: MathExprSubtypes) -> bool:
@@ -306,7 +306,7 @@ def _has_mathvar(expr: MathExprSubtypes) -> bool:
             return operands["expr1"] or operands["expr2"]
 
     traverser = Post(_MathVarFinder())
-    return traverser(expr)
+    return traverser(expr)  # type: ignore
 
 
 def _get_pauli_string_two_weight_info(

--- a/src/oqd_core/analysis/isinglike.py
+++ b/src/oqd_core/analysis/isinglike.py
@@ -86,7 +86,7 @@ def isinglike_analysis(
     allowed_terms: Optional[list[str]] = None,
 ) -> dict[str, NDArray[np.complex128]]:
     """
-    Creating the dictionary of coupling matrices for an `AnalogGate` instance that
+    Creates the dictionary of coupling matrices for an `AnalogGate` instance that
     implements an Ising-like Hamiltonian.
 
     Args:

--- a/src/oqd_core/analysis/isinglike.py
+++ b/src/oqd_core/analysis/isinglike.py
@@ -203,7 +203,7 @@ def _traverse(op: OperatorSubtypes) -> list[_PauliStringTerm]:
         right = _rescale_all_coefficients(right, -1)
         return left + right
     elif isinstance(op, OperatorScalarMul):
-        if _has_time_dependent_parameter(op.expr):
+        if _has_mathvar(op.expr):
             raise RuntimeError("ERROR: time-dependent parameter in Hamiltonian.\n")
         value = _evaluate_math_expr_to_complex_float(op.expr)
         products = _traverse(op.op)
@@ -255,18 +255,16 @@ def _has_bosonic_operator(op: OperatorSubtypes) -> bool:
         assert False, "unreachable; all OperatorSubtypes accounted for"
 
 
-def _has_time_dependent_parameter(expr: MathExprSubtypes) -> bool:
+def _has_mathvar(expr: MathExprSubtypes) -> bool:
     """
     Recursively traverses the math expression tree and checks if `MathVar` is present.
     """
     if isinstance(expr, MathTerminal):
         return isinstance(expr, MathVar)
     elif isinstance(expr, MathUnaryOp):
-        return _has_time_dependent_parameter(expr.expr)
+        return _has_mathvar(expr.expr)
     elif isinstance(expr, MathBinaryOp):
-        return _has_time_dependent_parameter(
-            expr.expr1
-        ) or _has_time_dependent_parameter(expr.expr2)
+        return _has_mathvar(expr.expr1) or _has_mathvar(expr.expr2)
     else:
         assert False, "unreachable; all MathExprSubtypes accounted for"
 

--- a/src/oqd_core/analysis/isinglike.py
+++ b/src/oqd_core/analysis/isinglike.py
@@ -135,12 +135,10 @@ def _build_coupling_matrix(
     """
     coupling_matrices: dict[str, NDArray[np.complex128]] = {}
 
-    for two_weight in two_weights:
+    for pair in two_weights:
         # this sorting guarantees that (pauli_term_min, pauli_term_max) is one of
         #     (X, Y), (X, Y), (X, Z), (Y, Y), (Y, Z), (Z, Z)
-        pauli_term_min, pauli_term_max = sorted(
-            [two_weight.pauli_term0, two_weight.pauli_term1]
-        )
+        pauli_term_min, pauli_term_max = sorted([pair.pauli_term0, pair.pauli_term1])
         i_min, pauli_str_min = pauli_term_min.index_and_string()
         i_max, pauli_str_max = pauli_term_max.index_and_string()
 
@@ -152,10 +150,10 @@ def _build_coupling_matrix(
             )
 
         if pauli_str_min == pauli_str_max:
-            coupling_matrices[matrix_key][i_min, i_max] = two_weight.coefficient
-            coupling_matrices[matrix_key][i_max, i_min] = two_weight.coefficient
+            coupling_matrices[matrix_key][i_min, i_max] = pair.coefficient
+            coupling_matrices[matrix_key][i_max, i_min] = pair.coefficient
         else:
-            coupling_matrices[matrix_key][i_min, i_max] = two_weight.coefficient
+            coupling_matrices[matrix_key][i_min, i_max] = pair.coefficient
 
     return coupling_matrices
 

--- a/src/oqd_core/analysis/isinglike.py
+++ b/src/oqd_core/analysis/isinglike.py
@@ -1,0 +1,347 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Optional
+import itertools
+
+from numpy.typing import NDArray
+import numpy as np
+
+from oqd_core.compiler.analog.passes import analog_operator_canonicalization
+from oqd_core.compiler.math.passes import evaluate_math_expr
+from oqd_core.interface.analog import AnalogGate
+from oqd_core.interface.analog.operator import OperatorSubtypes
+from oqd_core.interface.analog.operator import OperatorBinaryOp
+from oqd_core.interface.analog.operator import OperatorTerminal
+from oqd_core.interface.analog.operator import OperatorAdd
+from oqd_core.interface.analog.operator import OperatorSub
+from oqd_core.interface.analog.operator import OperatorKron
+from oqd_core.interface.analog.operator import OperatorScalarMul
+from oqd_core.interface.analog.operator import Annihilation
+from oqd_core.interface.analog.operator import Creation
+from oqd_core.interface.analog.operator import Identity
+from oqd_core.interface.analog.operator import Pauli
+from oqd_core.interface.analog.operator import PauliI
+from oqd_core.interface.analog.operator import PauliX
+from oqd_core.interface.analog.operator import PauliY
+from oqd_core.interface.analog.operator import PauliZ
+from oqd_core.interface.math import MathExprSubtypes
+from oqd_core.interface.math import MathTerminal
+from oqd_core.interface.math import MathVar
+from oqd_core.interface.math import MathUnaryOp
+from oqd_core.interface.math import MathBinaryOp
+
+
+__all__ = [
+    "isinglike_analysis",
+]
+
+
+@dataclass
+class _PauliStringTerm:
+    coefficient: np.complex128
+    operators: list[Pauli]
+
+
+@dataclass
+class _PauliTermInfo:
+    index: int
+    term: Pauli
+
+    def index_and_string(self) -> tuple[int, str]:
+        return self.index, _pauli_to_char(self.term)
+    
+    def __lt__(self, other) -> bool:
+        if not isinstance(other, _PauliTermInfo):
+            return NotImplemented
+        return _pauli_to_char(self.term) < _pauli_to_char(other.term)
+
+
+@dataclass
+class _PauliStringTwoWeightInfo:
+    coefficient: np.complex128
+    pauli_term0: _PauliTermInfo
+    pauli_term1: _PauliTermInfo
+
+
+
+def isinglike_analysis(gate: AnalogGate) -> dict[str, NDArray[np.complex128]]:
+    """
+    Creating the dictionary of coupling matrices for an `AnalogGate` instance that
+    implements an Ising-like Hamiltonian.
+
+    Raises a RuntimeError in any of the following cases:
+        - a bosonic mode operator is found in Hamiltonian expression
+        - a time-dependent parameter is found in Hamiltonian expression
+        - at least one Pauli string is not a two-weight Pauli string
+        - the analog operator canonicalization process raised an AssertionError
+        - the recursive traversal function to collect the Pauli strings found an operator
+          that it could not evaluate
+        - the Pauli strings are not all the same length
+    """
+    if _has_bosonic_operator(gate.hamiltonian):
+        raise RuntimeError("ERROR: found bosonic mode operator in Hamiltonian")
+
+    try:
+        canonicalized: AnalogGate = analog_operator_canonicalization(gate)
+    except AssertionError as e:
+        raise RuntimeError(f"ERROR: canonicalization function raised exception: {e}\n")
+
+    pauli_strings = _traverse(canonicalized.hamiltonian)
+    if len(pauli_strings) == 0:
+        return _empty_coupling_matrix_dict(0)
+
+    if not _are_all_pauli_strings_the_same_length(pauli_strings):
+        raise RuntimeError("ERROR: the Pauli strings are not all the same length\n")
+
+    two_weights: list[_PauliStringTwoWeightInfo] = []
+    for string in pauli_strings:
+        two_weight = _get_pauli_string_two_weight_info(string)
+        if two_weight is None:
+            raise RuntimeError("ERROR: found a Pauli string that isn't two-weight\n")
+        else:
+            two_weights.append(two_weight)
+
+    n_qubits = len(pauli_strings[0].operators)
+
+    return _build_coupling_matrix(two_weights, n_qubits)
+
+
+def _build_coupling_matrix(two_weights: list[_PauliStringTwoWeightInfo], n_qubits: int) -> dict[str, NDArray[np.complex128]]:
+    """
+    Creating the dictionary of coupling matrices from the two-weight information.
+
+    Args:
+        two_weights (list[_PauliStringTwoWeightInfo]): the coefficient and position/operator type information about
+            the two non-identity Pauli operators
+        n_qubits (int): the total number of qubits in the system
+
+    Returns:
+        dict[str, NDArray[np.complex128]]: the coupling matrices for the two-weight Pauli strings
+    """
+    coupling_matrices = _empty_coupling_matrix_dict(n_qubits)
+
+    for two_weight in two_weights:
+        # this sorting guarantees that (pauli_term_min, pauli_term_max) is one of
+        #     (X, Y), (X, Y), (X, Z), (Y, Y), (Y, Z), (Z, Z)
+        pauli_term_min, pauli_term_max = sorted([two_weight.pauli_term0, two_weight.pauli_term1])
+        i_min, pauli_str_min = pauli_term_min.index_and_string()
+        i_max, pauli_str_max = pauli_term_max.index_and_string()
+        
+        matrix_key = f"{pauli_str_min}{pauli_str_max}"
+        
+        if pauli_str_min == pauli_str_max:
+            coupling_matrices[matrix_key][i_min, i_max] = two_weight.coefficient
+            coupling_matrices[matrix_key][i_max, i_min] = two_weight.coefficient
+        else:
+            coupling_matrices[matrix_key][i_min, i_max] = two_weight.coefficient
+
+    return coupling_matrices
+
+
+def _pauli_to_char(pauli: Pauli) -> str:
+    """
+    Casts a Pauli operator to their respective string representation.
+    """
+    if isinstance(pauli, PauliX):
+        return "X"
+    elif isinstance(pauli, PauliY):
+        return "Y"
+    elif isinstance(pauli, PauliZ):
+        return "Z"
+    else:
+        assert False, "unreachable; only PauliX, PauliY, and PauliZ can be present"
+
+
+def _traverse(op: OperatorSubtypes) -> list[_PauliStringTerm]:
+    """
+    Recursively traverse the operator AST and collect all the Pauli strings and their coefficients.
+
+    Args:
+        op (OperatorSubtypes): the root of the operator AST
+
+    Raises:
+        RuntimeError:
+          - if a time-dependent parameter is found in the Hamiltonian expression
+          - if the recursive traversal function to collect the Pauli strings found
+            an operator that it could not evaluate
+          - if a math expression could not be cast to a `np.complex128`
+        
+    Returns:
+        list[_PauliStringTerm]: a sequence of all the Pauli strings and the coefficients
+    """
+    if isinstance(op, Pauli):
+        return [_PauliStringTerm(np.complex128(1.0, 0.0), [op])]
+    elif isinstance(op, OperatorAdd):
+        left = _traverse(op.op1)
+        right = _traverse(op.op2)
+        return left + right
+    elif isinstance(op, OperatorSub):
+        left = _traverse(op.op1)
+        right = _traverse(op.op2)
+        right = _rescale_all_coefficients(right, -1)
+        return left + right
+    elif isinstance(op, OperatorScalarMul):
+        if _has_time_dependent_parameter(op.expr):
+            raise RuntimeError("ERROR: time-dependent parameter in Hamiltonian.\n")
+        value = _evaluate_math_expr_to_complex_float(op.expr)
+        products = _traverse(op.op)
+        products = _rescale_all_coefficients(products, value)
+        return products
+    elif isinstance(op, OperatorKron):
+        left_products = _traverse(op.op1)
+        right_products = _traverse(op.op2)
+        products = []
+        for left, right in itertools.product(left_products, right_products):
+            products.append(
+                _PauliStringTerm(
+                    coefficient=left.coefficient * right.coefficient,
+                    operators=left.operators + right.operators,
+                )
+            )
+        return products
+    else:
+        raise RuntimeError(f"ERROR: cannot handle the following operator: {type(op)}")
+
+
+def _empty_coupling_matrix_dict(size: int) -> dict[str, NDArray]:
+    """
+    Create the default dictionary that maps the Pauli operator pairs to their respective
+    coupling matrices.
+    """
+    return {
+        "XX": np.zeros((size, size), dtype=np.complex128),
+        "XY": np.zeros((size, size), dtype=np.complex128),
+        "XZ": np.zeros((size, size), dtype=np.complex128),
+        "YY": np.zeros((size, size), dtype=np.complex128),
+        "YZ": np.zeros((size, size), dtype=np.complex128),
+        "ZZ": np.zeros((size, size), dtype=np.complex128),
+    }
+
+
+def _are_all_pauli_strings_the_same_length(strings: list[_PauliStringTerm]) -> bool:
+    """
+    Returns whether or not all Pauli strings in `strings` are the same length.
+    """
+    
+    if len(strings) == 0:
+        assert False, "unreachable; there must be at least one Pauli string"
+        
+    if len(strings) == 1:
+        return True
+    else:
+        size = len(strings[0].operators)
+        return all([size == len(prod.operators) for prod in strings[1:]])
+
+
+def _has_bosonic_operator(op: OperatorSubtypes) -> bool:
+    """
+    Recursively traverses the tree and checks if any of the Annihilation, Creation, or Identity
+    operators are present.
+    """
+    if isinstance(op, OperatorTerminal):
+        return isinstance(op, (Annihilation, Creation, Identity))
+    elif isinstance(op, OperatorBinaryOp):
+        return _has_bosonic_operator(op.op1) or _has_bosonic_operator(op.op2)
+    elif isinstance(op, OperatorScalarMul):
+        return _has_bosonic_operator(op.op)
+    else:
+        assert False, "unreachable; all OperatorSubtypes accounted for"
+
+
+def _has_time_dependent_parameter(expr: MathExprSubtypes) -> bool:
+    """
+    Recursively traverses the math expression tree and checks if `MathVar` is present.
+    """
+    if isinstance(expr, MathTerminal):
+        return isinstance(expr, MathVar)
+    elif isinstance(expr, MathUnaryOp):
+        return _has_time_dependent_parameter(expr.expr)
+    elif isinstance(expr, MathBinaryOp):
+        return _has_time_dependent_parameter(
+            expr.expr1
+        ) or _has_time_dependent_parameter(expr.expr2)
+    else:
+        assert False, "unreachable; all MathExprSubtypes accounted for"
+
+
+def _get_pauli_string_two_weight_info(
+    pauli_string: _PauliStringTerm,
+) -> Optional[_PauliStringTwoWeightInfo]:
+    """
+    Extract information about the two non-identity Pauli operator terms in the Pauli string.
+
+    If the Pauli string is a valid two-weight Pauli string, this functions returns an object
+    that holds the string's coefficient, and the indices and Pauli operator types of the
+    two non-identity Pauli operators.
+    
+    If the Pauli string is not a two-weight Pauli string, this function returns None.
+
+    Args:
+        string (_PauliStringTerm): the Pauli string to be analyzed
+    """
+    if any([not isinstance(op, Pauli) for op in pauli_string.operators]):
+        assert False, "unreachable; only Pauli operators should be in the Pauli string"
+
+    paulis: list[_PauliTermInfo] = []
+    for i, op in enumerate(pauli_string.operators):
+        if isinstance(op, PauliI):
+            continue
+
+        if len(paulis) >= 2:
+            return None
+
+        paulis.append(_PauliTermInfo(i, deepcopy(op)))
+
+    if len(paulis) != 2:
+        return None
+
+    return _PauliStringTwoWeightInfo(pauli_string.coefficient, paulis[0], paulis[1])
+
+
+def _rescale_all_coefficients(
+    pauli_strings: list[_PauliStringTerm],
+    value: int | float | np.complex128,
+) -> list[_PauliStringTerm]:
+    """
+    Multiply the coefficient of each Pauli string in `pauli_strings` by `value`.
+
+    Args:
+        pauli_strings (list[_PauliStringTerm]): the Pauli strings to be rescaled
+        value (int | float | np.complex128): the value to rescale them by
+
+    Returns:
+        list[_PauliStringTerm]: the rescaled Pauli strings
+    """
+    output: list[_PauliStringTerm] = deepcopy(pauli_strings)
+    for elem in output:
+        elem.coefficient *= value
+
+    return output
+
+
+def _evaluate_math_expr_to_complex_float(expr: MathExprSubtypes) -> np.complex128:
+    """
+    This function is a wrapper around the `evaluate_math_expr()` function that ensures that
+    the output can be converted to a scalar `np.complex128`.
+    """
+    value = evaluate_math_expr(expr)
+    if isinstance(value, complex):
+        return np.complex128(value)
+    if isinstance(value, int) or isinstance(value, float):
+        return np.complex128(value, 0.0)
+    else:
+        raise RuntimeError("ERROR: unable to cast math expression to a `np.complex128`.")

--- a/src/oqd_core/analysis/isinglike.py
+++ b/src/oqd_core/analysis/isinglike.py
@@ -173,10 +173,9 @@ def _build_coupling_matrix(
             )
 
         if pauli_str_min == pauli_str_max:
-            # TODO: FIX THIS
             # divide by 2 to account for double counting of the same term
-            coupling_matrices[matrix_key][i_min, i_max] = pair.coefficient
-            coupling_matrices[matrix_key][i_max, i_min] = pair.coefficient
+            coupling_matrices[matrix_key][i_min, i_max] = 0.5 * pair.coefficient
+            coupling_matrices[matrix_key][i_max, i_min] = 0.5 * pair.coefficient
         else:
             coupling_matrices[matrix_key][i_min, i_max] = pair.coefficient
 

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -243,7 +243,7 @@ class Test_isinglike_analysis:
 
         assert "XX" in output
         assert np.allclose(output["XX"], np.array([[0.0, 1.0], [1.0, 0.0]]))
-        
+
     def test_xx_minus_yy_2_qubits(self) -> None:
         gate = AnalogGate(hamiltonian=X @ X - Y @ Y)
         output = isinglike_analysis(gate)

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -40,12 +40,15 @@ from oqd_core.interface.analog.operator import PauliZ
 from oqd_core.interface.math import MathExprSubtypes
 from oqd_core.interface.math import MathTerminal
 from oqd_core.interface.math import MathVar
+from oqd_core.interface.math import MathAdd
+from oqd_core.interface.math import MathNum
 from oqd_core.interface.math import MathUnaryOp
 from oqd_core.interface.math import MathBinaryOp
 
 from oqd_core.analysis.isinglike import isinglike_analysis
 from oqd_core.analysis.isinglike import _get_pauli_string_two_weight_info
 from oqd_core.analysis.isinglike import _rescale_all_coefficients
+from oqd_core.analysis.isinglike import _has_mathvar
 from oqd_core.analysis.isinglike import _PauliStringTerm
 from oqd_core.analysis.isinglike import _PauliTermInfo
 from oqd_core.analysis.isinglike import _PauliStringTwoWeightInfo
@@ -146,3 +149,14 @@ def test_get_pauli_string_two_weight_info(
         assert actual is expected
     else:
         assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    [
+        (MathAdd(expr1=MathNum(value=1), expr2=MathNum(value=2)), False),
+        (MathAdd(expr1=MathNum(value=1), expr2=MathVar(name="x")), True),
+    ]
+)
+def test_has_mathvar(expr: MathExprSubtypes, expected: bool) -> None:
+    assert _has_mathvar(expr) == expected

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -71,10 +71,26 @@ def default_pauli_strings() -> list[_PauliStringTerm]:
     "value, expected",
     [
         # fmt: off
-        (1, (np.complex128(1.0, 0.0), np.complex128(2.0, 0.0), np.complex128(3.0, 1.0))),
-        (2, (np.complex128(2.0, 0.0), np.complex128(4.0, 0.0), np.complex128(6.0, 2.0))),
-        (3.0, (np.complex128(3.0, 0.0), np.complex128(6.0, 0.0), np.complex128(9.0, 3.0))),
-        (np.complex128(2.0, 3.0), (np.complex128(2.0, 3.0), np.complex128(4.0, 6.0), np.complex128(3.0, 11.0))),
+        (
+            1,
+            (np.complex128(1.0, 0.0), np.complex128(2.0, 0.0), np.complex128(3.0, 1.0)),
+        ),
+        (
+            2,
+            (np.complex128(2.0, 0.0), np.complex128(4.0, 0.0), np.complex128(6.0, 2.0)),
+        ),
+        (
+            3.0,
+            (np.complex128(3.0, 0.0), np.complex128(6.0, 0.0), np.complex128(9.0, 3.0)),
+        ),
+        (
+            np.complex128(2.0, 3.0),
+            (
+                np.complex128(2.0, 3.0),
+                np.complex128(4.0, 6.0),
+                np.complex128(3.0, 11.0),
+            ),
+        ),
         # fmt: on
     ],
 )
@@ -96,44 +112,39 @@ def test_rescale_all_coefficients(
         # fmt: off
         (
             _PauliStringTerm(1.0, [X, Y]),
-            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Y))
+            _PauliStringTwoWeightInfo(
+                np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Y)
+            ),
         ),
         (
             _PauliStringTerm(2.0, [X, Y]),
-            _PauliStringTwoWeightInfo(np.complex128(2.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Y))
+            _PauliStringTwoWeightInfo(
+                np.complex128(2.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Y)
+            ),
         ),
         (
             _PauliStringTerm(1.0, [X, Z]),
-            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Z))
+            _PauliStringTwoWeightInfo(
+                np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Z)
+            ),
         ),
         (
             _PauliStringTerm(1.0, [X, ID, Z]),
-            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(2, Z))
+            _PauliStringTwoWeightInfo(
+                np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(2, Z)
+            ),
         ),
         (
             _PauliStringTerm(1.0, [ID, ID, Y, ID, X, ID, ID, ID]),
-            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(2, Y), _PauliTermInfo(4, X))
+            _PauliStringTwoWeightInfo(
+                np.complex128(1.0, 0.0), _PauliTermInfo(2, Y), _PauliTermInfo(4, X)
+            ),
         ),
-        (
-            _PauliStringTerm(1.0, [X]),
-            None
-        ),
-        (
-            _PauliStringTerm(1.0, [X, ID]),
-            None
-        ),
-        (
-            _PauliStringTerm(1.0, [ID, X, ID]),
-            None
-        ),
-        (
-            _PauliStringTerm(1.0, [X, Y, Z]),
-            None
-        ),
-        (
-            _PauliStringTerm(1.0, [ID, X, ID, Y, Z]),
-            None
-        ),
+        (_PauliStringTerm(1.0, [X]), None),
+        (_PauliStringTerm(1.0, [X, ID]), None),
+        (_PauliStringTerm(1.0, [ID, X, ID]), None),
+        (_PauliStringTerm(1.0, [X, Y, Z]), None),
+        (_PauliStringTerm(1.0, [ID, X, ID, Y, Z]), None),
         # fmt: on
     ],
 )

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -243,6 +243,15 @@ class Test_isinglike_analysis:
 
         assert "XX" in output
         assert np.allclose(output["XX"], np.array([[0.0, 1.0], [1.0, 0.0]]))
+        
+    def test_xx_minus_yy_2_qubits(self) -> None:
+        gate = AnalogGate(hamiltonian=X @ X - Y @ Y)
+        output = isinglike_analysis(gate)
+
+        assert "XX" in output
+        assert np.allclose(output["XX"], np.array([[0.0, 1.0], [1.0, 0.0]]))
+        assert "YY" in output
+        assert np.allclose(output["YY"], np.array([[0.0, -1.0], [-1.0, 0.0]]))
 
     def test_xx_3_qubits(self) -> None:
         gate = AnalogGate(hamiltonian=X @ X @ ID)

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -19,7 +19,6 @@ from typing import Optional
 from numpy.typing import NDArray
 import numpy as np
 
-from oqd_core.compiler.analog.passes import analog_operator_canonicalization
 from oqd_core.compiler.math.passes import evaluate_math_expr
 from oqd_core.interface.analog import AnalogGate
 from oqd_core.interface.analog.operator import OperatorSubtypes
@@ -46,18 +45,26 @@ from oqd_core.interface.math import MathUnaryOp
 from oqd_core.interface.math import MathBinaryOp
 
 from oqd_core.analysis.isinglike import isinglike_analysis
+from oqd_core.analysis.isinglike import _are_all_pauli_strings_the_same_length
+from oqd_core.analysis.isinglike import _build_coupling_matrix
 from oqd_core.analysis.isinglike import _get_pauli_string_two_weight_info
-from oqd_core.analysis.isinglike import _rescale_all_coefficients
+from oqd_core.analysis.isinglike import _has_bosonic_operator
 from oqd_core.analysis.isinglike import _has_mathvar
+from oqd_core.analysis.isinglike import _pauli_to_char
+from oqd_core.analysis.isinglike import _rescale_all_coefficients
 from oqd_core.analysis.isinglike import _PauliStringTerm
 from oqd_core.analysis.isinglike import _PauliTermInfo
 from oqd_core.analysis.isinglike import _PauliStringTwoWeightInfo
 
 
+I = Identity()
+A = Annihilation()
+C = Creation()
 ID = PauliI()
 X = PauliX()
 Y = PauliY()
 Z = PauliZ()
+PST = _PauliStringTerm
 
 
 @pytest.fixture
@@ -83,7 +90,7 @@ def default_pauli_strings() -> list[_PauliStringTerm]:
 def test_rescale_all_coefficients(
     value: int | float | np.complex128,
     expected: tuple[np.complex128],
-    default_pauli_strings: list[_PauliStringTerm]
+    default_pauli_strings: list[_PauliStringTerm],
 ) -> None:
     rescaled = _rescale_all_coefficients(default_pauli_strings, value)
 
@@ -140,11 +147,10 @@ def test_rescale_all_coefficients(
     ],
 )
 def test_get_pauli_string_two_weight_info(
-    pauli_string: _PauliStringTerm,
-    expected: Optional[_PauliStringTwoWeightInfo]
+    pauli_string: _PauliStringTerm, expected: Optional[_PauliStringTwoWeightInfo]
 ) -> None:
     actual = _get_pauli_string_two_weight_info(pauli_string)
-    
+
     if actual is None:
         assert actual is expected
     else:
@@ -156,7 +162,323 @@ def test_get_pauli_string_two_weight_info(
     [
         (MathAdd(expr1=MathNum(value=1), expr2=MathNum(value=2)), False),
         (MathAdd(expr1=MathNum(value=1), expr2=MathVar(name="x")), True),
-    ]
+    ],
 )
 def test_has_mathvar(expr: MathExprSubtypes, expected: bool) -> None:
     assert _has_mathvar(expr) == expected
+
+
+@pytest.mark.parametrize(
+    "op, expected",
+    [
+        (OperatorAdd(op1=X, op2=Y), False),
+        (OperatorAdd(op1=X, op2=OperatorAdd(op1=Y, op2=C)), True),
+        (OperatorAdd(op1=X, op2=OperatorAdd(op1=A, op2=Z)), True),
+        (OperatorAdd(op1=I, op2=OperatorAdd(op1=I, op2=C)), True),
+    ],
+)
+def test_bosonic_operator(op: OperatorSubtypes, expected: bool) -> None:
+    assert _has_bosonic_operator(op) == expected
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    [
+        ([PST(1, [X, Y, Z]), PST(1, [X, Y, Z]), PST(1, [X, Y, Z])], True),
+        ([PST(1, [ID, Y, Z]), PST(1, [X, Y, ID])], True),
+        ([PST(1, [ID, Y, Z])], True),
+        ([PST(1, [Y, Z]), PST(1, [X, Z]), PST(1, [X, ID])], True),
+        ([PST(1, [X, Y, Y, Z]), PST(1, [X, ID, Y, Z]), PST(1, [X, ID, Y, Z])], True),
+        ([PST(1, [X, Y]), PST(1, [X, Y, Z]), PST(1, [X, Y, Z])], False),
+        ([PST(1, [Z]), PST(1, [Z]), PST(1, [X, Y, ID])], False),
+        ([PST(1, [Y, Z]), PST(1, [X, Z]), PST(1, [X, ID, Y])], False),
+        ([PST(1, [X, Y, Y, Z]), PST(1, [Y, Z]), PST(1, [X, ID, Y, Z])], False),
+    ],
+)
+def test_are_all_pauli_strings_the_same_length(
+    expr: MathExprSubtypes, expected: bool
+) -> None:
+    assert _are_all_pauli_strings_the_same_length(expr) == expected
+
+
+@pytest.mark.parametrize(
+    "pauli, expected",
+    [
+        (X, "X"),
+        (Y, "Y"),
+        (Z, "Z"),
+    ],
+)
+def test_pauli_to_char(pauli: Pauli, expected: str) -> None:
+    assert _pauli_to_char(pauli) == expected
+
+
+def test_build_coupling_matrix_empty() -> None:
+    assert _build_coupling_matrix([], 2) == {}
+
+
+def test_build_coupling_matrix_same_pauli_one_term() -> None:
+    PTI = _PauliTermInfo
+    PSTWI = _PauliStringTwoWeightInfo
+    two_weights = [PSTWI(np.complex128(1.0, 2.0), PTI(0, X), PTI(1, X))]
+    output = _build_coupling_matrix(two_weights, 2)
+
+    assert "XX" in output
+    assert np.allclose(
+        output["XX"],
+        np.array([[0.0, 1.0 + 2.0j], [1.0 + 2.0j, 0.0]], dtype=np.complex128),
+    )
+
+
+def test_build_coupling_matrix_same_pauli_three_term() -> None:
+    PTI = _PauliTermInfo
+    PSTWI = _PauliStringTwoWeightInfo
+    two_weights = [
+        PSTWI(np.complex128(1.0, 2.0), PTI(0, X), PTI(1, X)),
+        PSTWI(np.complex128(3.0, 4.0), PTI(1, X), PTI(2, X)),
+        PSTWI(np.complex128(5.0, 6.0), PTI(0, X), PTI(2, X)),
+    ]
+    output = _build_coupling_matrix(two_weights, 3)
+
+    assert "XX" in output
+    assert np.allclose(
+        output["XX"],
+        np.array(
+            [
+                [0.0 + 0.0j, 1.0 + 2.0j, 5.0 + 6.0j],
+                [1.0 + 2.0j, 0.0 + 0.0j, 3.0 + 4.0j],
+                [5.0 + 6.0j, 3.0 + 4.0j, 0.0 + 0.0j],
+            ],
+            dtype=np.complex128,
+        ),
+    )
+
+
+class Test_isinglike_analysis:
+    def test_xx_2_qubits(self) -> None:
+        gate = AnalogGate(hamiltonian=X @ X)
+        output = isinglike_analysis(gate)
+        
+        assert "XX" in output
+        assert np.allclose(
+            output["XX"],
+            np.array(
+                [
+                    [0.0, 1.0],
+                    [1.0, 0.0]
+                ]
+            )
+        )
+        
+    def test_xx_3_qubits(self) -> None:
+        gate = AnalogGate(hamiltonian=X @ X @ ID)
+        output = isinglike_analysis(gate)
+        
+        assert "XX" in output
+        assert np.allclose(
+            output["XX"],
+            np.array(
+                [
+                    [0.0, 1.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0]
+                ]
+            )
+        )
+        
+    def test_xy_2_qubits(self) -> None:
+        gate = AnalogGate(hamiltonian=2.0 * X @ Y)
+        output = isinglike_analysis(gate)
+        
+        assert "XY" in output
+        assert np.allclose(
+            output["XY"],
+            np.array(
+                [
+                    [0.0, 2.0],
+                    [0.0, 0.0]
+                ]
+            )
+        )
+        
+    def test_yx_2_qubits(self) -> None:
+        gate = AnalogGate(hamiltonian=2.0 * Y @ X)
+        output = isinglike_analysis(gate)
+        
+        assert "XY" in output
+        assert np.allclose(
+            output["XY"],
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [2.0, 0.0]
+                ]
+            )
+        )
+        
+    def test_yx_zz_2_qubits(self) -> None:
+        gate = AnalogGate(hamiltonian=2.0 * Y @ X + 3.0 * Z @ Z)
+        output = isinglike_analysis(gate)
+        
+        assert "XY" in output
+        assert np.allclose(
+            output["XY"],
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [2.0, 0.0]
+                ]
+            )
+        )
+        
+        assert "ZZ" in output
+        assert np.allclose(
+            output["ZZ"],
+            np.array(
+                [
+                    [0.0, 3.0],
+                    [3.0, 0.0]
+                ]
+            )
+        )
+    
+    def test_multiterm_4_qubits(self) -> None:
+        """
+        This test makes sure that it is possible to get all 6 kinds of terms
+        in the output, and that large values can be handled.
+        """
+        # fmt: off
+        gate = AnalogGate(
+            hamiltonian=1.0 * X @ X @ ID @ ID
+                      + 2.0 * X @ ID @ X @ ID
+                      + 3.0 * ID @ ID @ X @ X
+                      + 4.0 * Y @ ID @ X @ ID
+                      - 5.0 * Z @ ID @ X @ ID
+                      - 6.0 * Z @ Y @ ID @ ID
+                      - 7.0 * Y @ Z @ ID @ ID
+                      - 8.0 * ID @ ID @ Y @ Y
+                      - 9.0 * ID @ ID @ Z @ Z
+        )
+        # fmt: on
+        
+        output = isinglike_analysis(gate)
+        
+        assert "XX" in output
+        assert np.allclose(
+            output["XX"],
+            np.array(
+                [
+                    [0.0, 1.0, 2.0, 0.0],
+                    [1.0, 0.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0, 3.0],
+                    [0.0, 0.0, 3.0, 0.0],
+                ]
+            )
+        )
+        
+        assert "XY" in output
+        assert np.allclose(
+            output["XY"],
+            np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [4.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            )
+        )
+        
+        assert "XZ" in output
+        assert np.allclose(
+            output["XZ"],
+            np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [-5.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            )
+        )
+        
+        assert "YY" in output
+        assert np.allclose(
+            output["YY"],
+            np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, -8.0],
+                    [0.0, 0.0, -8.0, 0.0],
+                ]
+            )
+        )
+        
+        assert "YZ" in output
+        assert np.allclose(
+            output["YZ"],
+            np.array(
+                [
+                    [0.0, -7.0, 0.0, 0.0],
+                    [-6.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            )
+        )
+        
+        assert "ZZ" in output
+        assert np.allclose(
+            output["ZZ"],
+            np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, -9.0],
+                    [0.0, 0.0, -9.0, 0.0],
+                ]
+            )
+        )
+    
+    def test_raises_bosonic_operator(self) -> None:
+        gate = AnalogGate(hamiltonian=1.0 * X @ C)
+
+        with pytest.raises(RuntimeError):
+            isinglike_analysis(gate)
+
+    def test_raises_time_dependent_operator(self) -> None:
+        gate = AnalogGate(hamiltonian=MathVar(name="t") * X @ C)
+
+        with pytest.raises(RuntimeError):
+            isinglike_analysis(gate)
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            1.0 * X @ ID,
+            1.0 * X @ Y + 2.0 * X @ ID,
+            1.0 * ID @ X @ Y + 2.0 * X @ ID @ ID,
+            1.0 * ID @ X @ Y + 2.0 * X @ Z @ ID + 3.0 * X @ Z @ Y,
+        ],
+    )
+    def test_raises_pauli_string_weight(self, op: OperatorSubtypes) -> None:
+        gate = AnalogGate(hamiltonian=op)
+
+        with pytest.raises(RuntimeError):
+            isinglike_analysis(gate)
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            1.0 * X @ Y + 2.0 * X @ Z @ ID,
+            1.0 * X @ Y + 1.0 * Z @ Y + 2.0 * X @ Z @ ID,
+            1.0 * X @ Y + 1.0 * Z @ ID @ Y + 2.0 * X @ Z @ ID,
+            1.0 * X @ Y + 1.0 * Z @ ID @ Y + 2.0 * X @ Z @ ID @ ID @ ID,
+        ],
+    )
+    def test_raises_different_length_paulis(self, op: OperatorSubtypes) -> None:
+        gate = AnalogGate(hamiltonian=op)
+
+        with pytest.raises(RuntimeError):
+            isinglike_analysis(gate)

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -70,28 +70,10 @@ def default_pauli_strings() -> list[_PauliStringTerm]:
 @pytest.mark.parametrize(
     "value, expected",
     [
-        # fmt: off
-        (
-            1,
-            (np.complex128(1.0, 0.0), np.complex128(2.0, 0.0), np.complex128(3.0, 1.0)),
-        ),
-        (
-            2,
-            (np.complex128(2.0, 0.0), np.complex128(4.0, 0.0), np.complex128(6.0, 2.0)),
-        ),
-        (
-            3.0,
-            (np.complex128(3.0, 0.0), np.complex128(6.0, 0.0), np.complex128(9.0, 3.0)),
-        ),
-        (
-            np.complex128(2.0, 3.0),
-            (
-                np.complex128(2.0, 3.0),
-                np.complex128(4.0, 6.0),
-                np.complex128(3.0, 11.0),
-            ),
-        ),
-        # fmt: on
+        (1, ((1.0 + 0.0j), (2.0 + 0.0j), (3.0 + 1.0j))),
+        (2, ((2.0 + 0.0j), (4.0 + 0.0j), (6.0 + 2.0j))),
+        (3, ((3.0 + 0.0j), (6.0 + 0.0j), (9.0 + 3.0j))),
+        (2.0 + 3.0j, ((2.0 + 3.0j), (4.0 + 6.0j), (3.0 + 11.0j))),
     ],
 )
 def test_rescale_all_coefficients(
@@ -109,7 +91,6 @@ def test_rescale_all_coefficients(
 @pytest.mark.parametrize(
     "pauli_string, expected",
     [
-        # fmt: off
         (
             _PauliStringTerm(1.0, [X, Y]),
             _PauliStringTwoWeightInfo(
@@ -145,7 +126,6 @@ def test_rescale_all_coefficients(
         (_PauliStringTerm(1.0, [ID, X, ID]), None),
         (_PauliStringTerm(1.0, [X, Y, Z]), None),
         (_PauliStringTerm(1.0, [ID, X, ID, Y, Z]), None),
-        # fmt: on
     ],
 )
 def test_get_pauli_string_two_weight_info(
@@ -403,7 +383,7 @@ class Test_isinglike_analysis:
             isinglike_analysis(gate)
 
     def test_raises_time_dependent_operator(self) -> None:
-        gate = AnalogGate(hamiltonian=MathVar(name="t") * X @ C)
+        gate = AnalogGate(hamiltonian=MathVar(name="t") * X @ Y)
 
         with pytest.raises(RuntimeError):
             isinglike_analysis(gate)

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -1,0 +1,148 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from typing import Optional
+
+from numpy.typing import NDArray
+import numpy as np
+
+from oqd_core.compiler.analog.passes import analog_operator_canonicalization
+from oqd_core.compiler.math.passes import evaluate_math_expr
+from oqd_core.interface.analog import AnalogGate
+from oqd_core.interface.analog.operator import OperatorSubtypes
+from oqd_core.interface.analog.operator import OperatorBinaryOp
+from oqd_core.interface.analog.operator import OperatorTerminal
+from oqd_core.interface.analog.operator import OperatorAdd
+from oqd_core.interface.analog.operator import OperatorSub
+from oqd_core.interface.analog.operator import OperatorKron
+from oqd_core.interface.analog.operator import OperatorScalarMul
+from oqd_core.interface.analog.operator import Annihilation
+from oqd_core.interface.analog.operator import Creation
+from oqd_core.interface.analog.operator import Identity
+from oqd_core.interface.analog.operator import Pauli
+from oqd_core.interface.analog.operator import PauliI
+from oqd_core.interface.analog.operator import PauliX
+from oqd_core.interface.analog.operator import PauliY
+from oqd_core.interface.analog.operator import PauliZ
+from oqd_core.interface.math import MathExprSubtypes
+from oqd_core.interface.math import MathTerminal
+from oqd_core.interface.math import MathVar
+from oqd_core.interface.math import MathUnaryOp
+from oqd_core.interface.math import MathBinaryOp
+
+from oqd_core.analysis.isinglike import isinglike_analysis
+from oqd_core.analysis.isinglike import _get_pauli_string_two_weight_info
+from oqd_core.analysis.isinglike import _rescale_all_coefficients
+from oqd_core.analysis.isinglike import _PauliStringTerm
+from oqd_core.analysis.isinglike import _PauliTermInfo
+from oqd_core.analysis.isinglike import _PauliStringTwoWeightInfo
+
+
+ID = PauliI()
+X = PauliX()
+Y = PauliY()
+Z = PauliZ()
+
+
+@pytest.fixture
+def default_pauli_strings() -> list[_PauliStringTerm]:
+    return [
+        _PauliStringTerm(1.0, [X, Y, Z]),
+        _PauliStringTerm(2.0, [X, Y, Z]),
+        _PauliStringTerm((3.0 + 1.0j), [X, Y, Z]),
+    ]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # fmt: off
+        (1, (np.complex128(1.0, 0.0), np.complex128(2.0, 0.0), np.complex128(3.0, 1.0))),
+        (2, (np.complex128(2.0, 0.0), np.complex128(4.0, 0.0), np.complex128(6.0, 2.0))),
+        (3.0, (np.complex128(3.0, 0.0), np.complex128(6.0, 0.0), np.complex128(9.0, 3.0))),
+        (np.complex128(2.0, 3.0), (np.complex128(2.0, 3.0), np.complex128(4.0, 6.0), np.complex128(3.0, 11.0))),
+        # fmt: on
+    ],
+)
+def test_rescale_all_coefficients(
+    value: int | float | np.complex128,
+    expected: tuple[np.complex128],
+    default_pauli_strings: list[_PauliStringTerm]
+) -> None:
+    rescaled = _rescale_all_coefficients(default_pauli_strings, value)
+
+    assert np.allclose(rescaled[0].coefficient, expected[0])
+    assert np.allclose(rescaled[1].coefficient, expected[1])
+    assert np.allclose(rescaled[2].coefficient, expected[2])
+
+
+@pytest.mark.parametrize(
+    "pauli_string, expected",
+    [
+        # fmt: off
+        (
+            _PauliStringTerm(1.0, [X, Y]),
+            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Y))
+        ),
+        (
+            _PauliStringTerm(2.0, [X, Y]),
+            _PauliStringTwoWeightInfo(np.complex128(2.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Y))
+        ),
+        (
+            _PauliStringTerm(1.0, [X, Z]),
+            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(1, Z))
+        ),
+        (
+            _PauliStringTerm(1.0, [X, ID, Z]),
+            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(0, X), _PauliTermInfo(2, Z))
+        ),
+        (
+            _PauliStringTerm(1.0, [ID, ID, Y, ID, X, ID, ID, ID]),
+            _PauliStringTwoWeightInfo(np.complex128(1.0, 0.0), _PauliTermInfo(2, Y), _PauliTermInfo(4, X))
+        ),
+        (
+            _PauliStringTerm(1.0, [X]),
+            None
+        ),
+        (
+            _PauliStringTerm(1.0, [X, ID]),
+            None
+        ),
+        (
+            _PauliStringTerm(1.0, [ID, X, ID]),
+            None
+        ),
+        (
+            _PauliStringTerm(1.0, [X, Y, Z]),
+            None
+        ),
+        (
+            _PauliStringTerm(1.0, [ID, X, ID, Y, Z]),
+            None
+        ),
+        # fmt: on
+    ],
+)
+def test_get_pauli_string_two_weight_info(
+    pauli_string: _PauliStringTerm,
+    expected: Optional[_PauliStringTwoWeightInfo]
+) -> None:
+    actual = _get_pauli_string_two_weight_info(pauli_string)
+    
+    if actual is None:
+        assert actual is expected
+    else:
+        assert actual == expected

--- a/tests/test_analysis/test_isinglike.py
+++ b/tests/test_analysis/test_isinglike.py
@@ -208,7 +208,7 @@ def test_build_coupling_matrix_same_pauli_one_term() -> None:
     assert "XX" in output
     assert np.allclose(
         output["XX"],
-        np.array([[0.0, 1.0 + 2.0j], [1.0 + 2.0j, 0.0]], dtype=np.complex128),
+        0.5 * np.array([[0.0, 1.0 + 2.0j], [1.0 + 2.0j, 0.0]], dtype=np.complex128),
     )
 
 
@@ -225,7 +225,8 @@ def test_build_coupling_matrix_same_pauli_three_term() -> None:
     assert "XX" in output
     assert np.allclose(
         output["XX"],
-        np.array(
+        0.5
+        * np.array(
             [
                 [0.0 + 0.0j, 1.0 + 2.0j, 5.0 + 6.0j],
                 [1.0 + 2.0j, 0.0 + 0.0j, 3.0 + 4.0j],
@@ -242,16 +243,16 @@ class Test_isinglike_analysis:
         output = isinglike_analysis(gate)
 
         assert "XX" in output
-        assert np.allclose(output["XX"], np.array([[0.0, 1.0], [1.0, 0.0]]))
+        assert np.allclose(output["XX"], 0.5 * np.array([[0.0, 1.0], [1.0, 0.0]]))
 
     def test_xx_minus_yy_2_qubits(self) -> None:
         gate = AnalogGate(hamiltonian=X @ X - Y @ Y)
         output = isinglike_analysis(gate)
 
         assert "XX" in output
-        assert np.allclose(output["XX"], np.array([[0.0, 1.0], [1.0, 0.0]]))
+        assert np.allclose(output["XX"], 0.5 * np.array([[0.0, 1.0], [1.0, 0.0]]))
         assert "YY" in output
-        assert np.allclose(output["YY"], np.array([[0.0, -1.0], [-1.0, 0.0]]))
+        assert np.allclose(output["YY"], 0.5 * np.array([[0.0, -1.0], [-1.0, 0.0]]))
 
     def test_xx_3_qubits(self) -> None:
         gate = AnalogGate(hamiltonian=X @ X @ ID)
@@ -259,7 +260,8 @@ class Test_isinglike_analysis:
 
         assert "XX" in output
         assert np.allclose(
-            output["XX"], np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+            output["XX"],
+            0.5 * np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
         )
 
     def test_xy_2_qubits(self) -> None:
@@ -284,7 +286,7 @@ class Test_isinglike_analysis:
         assert np.allclose(output["XY"], np.array([[0.0, 0.0], [2.0, 0.0]]))
 
         assert "ZZ" in output
-        assert np.allclose(output["ZZ"], np.array([[0.0, 3.0], [3.0, 0.0]]))
+        assert np.allclose(output["ZZ"], 0.5 * np.array([[0.0, 3.0], [3.0, 0.0]]))
 
     def test_multiterm_4_qubits(self) -> None:
         """
@@ -310,7 +312,8 @@ class Test_isinglike_analysis:
         assert "XX" in output
         assert np.allclose(
             output["XX"],
-            np.array(
+            0.5
+            * np.array(
                 [
                     [0.0, 1.0, 2.0, 0.0],
                     [1.0, 0.0, 0.0, 0.0],
@@ -349,7 +352,8 @@ class Test_isinglike_analysis:
         assert "YY" in output
         assert np.allclose(
             output["YY"],
-            np.array(
+            0.5
+            * np.array(
                 [
                     [0.0, 0.0, 0.0, 0.0],
                     [0.0, 0.0, 0.0, 0.0],
@@ -375,7 +379,8 @@ class Test_isinglike_analysis:
         assert "ZZ" in output
         assert np.allclose(
             output["ZZ"],
-            np.array(
+            0.5
+            * np.array(
                 [
                     [0.0, 0.0, 0.0, 0.0],
                     [0.0, 0.0, 0.0, 0.0],


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This adds a function `isinglike_analysis()`. It takes an `AnalogGate` instance that implements an Ising-like Hamiltonian, and returns a dictionary that maps the type of interaction (`XX`, `XY`, `YY`, etc.) to the corresponding coupling matrix. If the input is invalid, for any of the reasons given in the docstring, a `RuntimeError` is raised.

It also has an optional argument `allowed_terms` that allows users to choose which of the Ising-like interaction types should be allowed in the Hamiltonian.

* **What is the current behavior?** (You can also link to an open issue here)

this change addresses #59


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need 
to make in their application due to this PR?)

There is no breaking change.


* **Other information**:

I have no idea how to update the docs.

I'm not entirely familiar with all the literature and terminology in this subfield, so I'm not 100% sure if the outputs (in the unit tests) are the intended outputs.