### PR TITLE
Check if an analog AnalogGate implements an Ising-like Hamiltonian [Unitary Hack]

### DIFF
--- a/src/oqd_core/interface/analog/operator.py
+++ b/src/oqd_core/interface/analog/operator.py
@@ -12,295 +12,253 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
+import numpy as np
 
-from typing import Union
-
-from oqd_compiler_infrastructure import TypeReflectBaseModel
-
-########################################################################################
-from oqd_core.interface.math import (
-    MathExpr,
-    MathExprSubtypes,
-    MathImag,
-    MathMul,
-    MathNum,
+from oqd_compiler_infrastructure import RewriteRule, Post
+from oqd_core.interface.analog.operation import AnalogGate
+from oqd_core.interface.analog.operator import (
+    Operator, OperatorAdd, OperatorScalarMul, OperatorKron,
+    Pauli, PauliI, PauliX, PauliY, PauliZ,
+    Ladder, # Base class for Creation, Annihilation, Identity (bosonic)
 )
-
-########################################################################################
-
-__all__ = [
-    "Operator",
-    "OperatorTerminal",
-    "Pauli",
-    "PauliI",
-    "PauliX",
-    "PauliY",
-    "PauliZ",
-    "PauliPlus",
-    "PauliMinus",
-    "Ladder",
-    "Creation",
-    "Annihilation",
-    "Identity",
-    "OperatorBinaryOp",
-    "OperatorAdd",
-    "OperatorSub",
-    "OperatorMul",
-    "OperatorScalarMul",
-    "OperatorKron",
-    "OperatorSubtypes",
-]
+from oqd_core.interface.math import MathNum
 
 
-########################################################################################
+# Helper class to determine number of qubit registers and check for bosonic modes / consistency
+class QubitCountRule(RewriteRule):
+    def __init__(self):
+        super().__init__()
+        self.n_qreg = 0
+        self.n_qmode = 0
+        self.consistent_qreg_size = True
+        self._processed_term_ops = set() # Avoid reprocessing shared sub-expressions if they are roots of terms
 
+    def _update_qreg_size(self, size):
+        if size <= 0: # qreg size must be positive if qubits are involved
+            self.consistent_qreg_size = False
+            return
+        if self.n_qreg == 0:
+            self.n_qreg = size
+        elif self.n_qreg != size:
+            self.consistent_qreg_size = False
 
-class Operator(TypeReflectBaseModel):
+    def _flatten_and_count_ops_in_term(self, op_node):
+        q_count = 0
+        m_count = 0
+        
+        elements = []
+        # Recursive helper to flatten Kron products and collect Pauli/Ladder ops
+        def _recursive_flatten(op):
+            nonlocal q_count, m_count # Allow modification of outer scope variables
+            if isinstance(op, OperatorKron):
+                _recursive_flatten(op.op1)
+                _recursive_flatten(op.op2)
+            elif isinstance(op, Pauli):
+                elements.append(op)
+                q_count += 1
+            elif isinstance(op, Ladder):
+                elements.append(op)
+                m_count += 1
+            else: # Contains something other than Pauli or Ladder
+                self.consistent_qreg_size = False
+        
+        _recursive_flatten(op_node)
+        return q_count, m_count
+
+    def _process_operator_part(self, op_part: Operator):
+        if id(op_part) in self._processed_term_ops:
+            return
+        self._processed_term_ops.add(id(op_part))
+
+        q_count, m_count = self._flatten_and_count_ops_in_term(op_part)
+        
+        if not self.consistent_qreg_size: return
+
+        if m_count > 0:
+            self.n_qmode += m_count 
+        
+        if q_count > 0:
+            self._update_qreg_size(q_count)
+
+    def map_OperatorScalarMul(self, model: OperatorScalarMul):
+        if not self.consistent_qreg_size: return model
+        self._process_operator_part(model.op)
+        self.visit(model.op) # Continue traversal
+        return model
+
+    def map_OperatorKron(self, model: OperatorKron): # Handles terms like X@X (implicit coeff 1)
+        if not self.consistent_qreg_size: return model
+        self._process_operator_part(model)
+        # No self.visit needed here as _process_operator_part flattens it
+        return model
+    
+    def map_Pauli(self, model: Pauli): # Handles terms like X (implicit coeff 1)
+        if not self.consistent_qreg_size: return model
+        # This implies a term with a single Pauli operator.
+        # For n_qreg counting, this term involves 1 qubit.
+        self._update_qreg_size(1)
+        self._processed_term_ops.add(id(model))
+        return model
+
+    def map_Ladder(self, model: Ladder): # Handles terms like A (implicit coeff 1)
+        if not self.consistent_qreg_size: return model
+        self.n_qmode += 1
+        self._processed_term_ops.add(id(model))
+        return model
+    
+    def map_OperatorAdd(self, model: OperatorAdd):
+        if not self.consistent_qreg_size: return model
+        self.visit(model.op1)
+        self.visit(model.op2)
+        return model
+
+# Main analysis class
+class IsingAnalysisRule(RewriteRule):
+    def __init__(self, n_qreg, coupling_matrices_dict):
+        super().__init__()
+        self.n_qreg = n_qreg
+        self.coupling_matrices = coupling_matrices_dict
+        self.is_ising_like_overall = True
+
+    def _get_pauli_char(self, pauli_op: Pauli):
+        if isinstance(pauli_op, PauliX): return 'X'
+        if isinstance(pauli_op, PauliY): return 'Y'
+        if isinstance(pauli_op, PauliZ): return 'Z'
+        if isinstance(pauli_op, PauliI): return 'I'
+        return None 
+
+    def _flatten_kron_for_ising_check(self, op_node):
+        ordered_paulis = []
+        # Recursive helper to flatten Kron products and collect Pauli ops in order
+        def _recursive_flatten(op):
+            if not self.is_ising_like_overall: return
+
+            if isinstance(op, OperatorKron):
+                _recursive_flatten(op.op1)
+                _recursive_flatten(op.op2)
+            elif isinstance(op, Pauli):
+                ordered_paulis.append(op)
+            elif isinstance(op, Ladder): # Rule 1: No bosonic
+                self.is_ising_like_overall = False
+            else: # Non-Pauli/Ladder in Kron
+                self.is_ising_like_overall = False
+        
+        _recursive_flatten(op_node)
+        return ordered_paulis
+
+    def _process_term(self, operator_part: Operator, coefficient_val: float):
+        if not self.is_ising_like_overall: return
+
+        pauli_ops_in_order = self._flatten_kron_for_ising_check(operator_part)
+
+        if not self.is_ising_like_overall: return 
+
+        if len(pauli_ops_in_order) != self.n_qreg:
+            self.is_ising_like_overall = False 
+            return
+
+        non_identity_terms = [] # List of (char, index)
+        for i, p_op in enumerate(pauli_ops_in_order):
+            char = self._get_pauli_char(p_op)
+            if char is None: 
+                self.is_ising_like_overall = False; return
+            if char != 'I':
+                non_identity_terms.append((char, i))
+        
+        if len(non_identity_terms) != 2: # Rule 2: Must be weight-2
+            self.is_ising_like_overall = False
+            return
+
+        p1_char, idx1 = non_identity_terms[0]
+        p2_char, idx2 = non_identity_terms[1]
+        
+        matrix_key = f"{p1_char}{p2_char}"
+        self.coupling_matrices[matrix_key][idx1, idx2] += coefficient_val
+        
+        # For XX, YY, ZZ terms, make the matrix symmetric by convention J_ij = J_ji
+        if p1_char == p2_char and idx1 != idx2: 
+            self.coupling_matrices[matrix_key][idx2, idx1] += coefficient_val
+
+    def map_OperatorScalarMul(self, model: OperatorScalarMul):
+        if not self.is_ising_like_overall: return model
+
+        if not isinstance(model.expr, MathNum): # Rule 3: Time-independent coeff
+            self.is_ising_like_overall = False
+            return model
+        
+        # Optionally check if model.expr.value is real if required by a stricter definition
+        # if isinstance(model.expr.value, complex):
+        #     self.is_ising_like_overall = False; return model
+
+        self._process_term(model.op, float(model.expr.value))
+        self.visit(model.op) 
+        return model
+
+    def map_OperatorKron(self, model: OperatorKron): 
+        if not self.is_ising_like_overall: return model
+        self._process_term(model, 1.0) # Implicit coefficient of 1.0
+        return model
+
+    def map_Pauli(self, model: Pauli): # Single Pauli term in a sum
+        self.is_ising_like_overall = False # Not weight-2 for Ising interaction term
+        return model
+    
+    def map_Ladder(self, model: Ladder): 
+        self.is_ising_like_overall = False # Bosonic
+        return model
+
+    def map_OperatorAdd(self, model: OperatorAdd):
+        if not self.is_ising_like_overall: return model
+        self.visit(model.op1)
+        self.visit(model.op2)
+        return model
+
+def ising_hamiltonian_analysis(gate: AnalogGate):
     """
-    Class representing the abstract syntax tree (AST) for a quantum operator
+    Analyzes an AnalogGate's Hamiltonian to check if it's Ising-like and extracts coupling matrices.
+
+    An Ising-like Hamiltonian must satisfy:
+    1. Composed of only qubit registers (no bosonic mode operators).
+    2. Each additive term is a weight-2 Pauli string (e.g., c * X_i @ Z_j).
+       Exactly two Pauli operators in the tensor product must be non-identity.
+    3. Coefficients must be time-independent (represented by MathNum).
+
+    Args:
+        gate (AnalogGate): The analog gate to analyze.
+
+    Returns:
+        dict: A dictionary of coupling matrices (e.g., 'XX', 'XY', etc.) as numpy arrays
+              if the Hamiltonian is Ising-like. For 'XX', 'YY', 'ZZ' matrices, symmetry
+              (J_ij = J_ji) is enforced.
+        None: If the Hamiltonian is not Ising-like or an error occurs.
     """
-
-    def __neg__(self):
-        return OperatorScalarMul(op=self, expr=MathNum(value=-1))
-
-    def __pos__(self):
-        return self
-
-    def __add__(self, other):
-        return OperatorAdd(op1=self, op2=other)
-
-    def __sub__(self, other):
-        return OperatorSub(op1=self, op2=other)
-
-    def __matmul__(self, other):
-        if isinstance(other, MathExpr):
-            raise TypeError(
-                "Tried Kron product between Operator and MathExpr. "
-                + "Scalar multiplication of MathExpr and Operator should be bracketed when perfoming Kron product."
-            )
-        return OperatorKron(op1=self, op2=other)
-
-    def __mul__(self, other):
-        if isinstance(other, Operator):
-            return OperatorMul(op1=self, op2=other)
-        else:
-            other = MathExpr.cast(other)
-            return OperatorScalarMul(op=self, expr=other)
-
-    def __rmul__(self, other):
-        other = MathExpr.cast(other)
-        return self * other
-
-    pass
-
-
-########################################################################################
-
-
-class OperatorTerminal(Operator):
-    """
-    Class representing a terminal in the [`Operator`][oqd_core.interface.analog.operator.Operator] abstract syntax tree (AST)
-    """
-
-    pass
-
-
-########################################################################################
-
-
-class Pauli(OperatorTerminal):
-    """
-    Class representing a Pauli operator
-    """
-
-    pass
-
-
-class PauliI(Pauli):
-    """
-    Class for the Pauli I operator
-    """
-
-    pass
-
-
-class PauliX(Pauli):
-    """
-    Class for the Pauli X operator
-    """
-
-    pass
-
-
-class PauliY(Pauli):
-    """
-    Class for the Pauli Y operator
-    """
-
-    pass
-
-
-class PauliZ(Pauli):
-    """
-    Class for the Pauli Z operator
-    """
-
-    pass
-
-
-def PauliPlus():
-    """
-    Function that constructs the Pauli + operator
-    """
-    return OperatorAdd(
-        op1=PauliX(),
-        op2=OperatorScalarMul(
-            op=PauliY(), expr=MathMul(expr1=MathImag(), expr2=MathNum(value=1))
-        ),
-    )
-
-
-def PauliMinus():
-    """
-    Function that constructs the Pauli - operator
-    """
-    return OperatorAdd(
-        op1=PauliX(),
-        op2=OperatorScalarMul(
-            op=PauliY(), expr=MathMul(expr1=MathImag(), expr2=MathNum(value=-1))
-        ),
-    )
-
-
-########################################################################################
-
-
-class Ladder(OperatorTerminal):
-    """
-    Class representing a ladder operator in Fock space
-    """
-
-    pass
-
-
-class Creation(Ladder):
-    """
-    Class for the Creation operator in Fock space
-    """
-
-    pass
-
-
-class Annihilation(Ladder):
-    """
-    Class for the Annihilation operator in Fock space
-    """
-
-    pass
-
-
-class Identity(Ladder):
-    """
-    Class for the Identity operator in Fock space
-    """
-
-    pass
-
-
-########################################################################################
-
-
-class OperatorScalarMul(Operator):
-    """
-    Class representing scalar multiplication of an [`Operator`][oqd_core.interface.analog.operator.Operator] and a
-    [`MathExpr`][oqd_core.interface.math.MathExpr]
-
-    Attributes:
-        op (Operator): [`Operator`][oqd_core.interface.analog.operator.Operator] to multiply
-        expr (MathExpr): [`MathExpr`][oqd_core.interface.math.MathExpr] to multiply by
-    """
-
-    op: OperatorSubtypes
-    expr: MathExprSubtypes
-
-
-class OperatorBinaryOp(Operator):
-    """
-    Class representing binary operations on [`Operators`][oqd_core.interface.analog.operator.Operator]
-    """
-
-    pass
-
-
-class OperatorAdd(OperatorBinaryOp):
-    """
-    Class representing the addition of [`Operators`][oqd_core.interface.analog.operator.Operator]
-
-    Attributes:
-        op1 (Operator): Left hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-        op2 (Operator): Right hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-    """
-
-    op1: OperatorSubtypes
-    op2: OperatorSubtypes
-
-
-class OperatorSub(OperatorBinaryOp):
-    """
-    Class representing the subtraction of [`Operators`][oqd_core.interface.analog.operator.Operator]
-
-    Attributes:
-        op1 (Operator): Left hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-        op2 (Operator): Right hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-    """
-
-    op1: OperatorSubtypes
-    op2: OperatorSubtypes
-
-
-class OperatorMul(OperatorBinaryOp):
-    """
-    Class representing the multiplication of [`Operators`][oqd_core.interface.analog.operator.Operator]
-
-    Attributes:
-        op1 (Operator): Left hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-        op2 (Operator): Right hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-    """
-
-    op1: OperatorSubtypes
-    op2: OperatorSubtypes
-
-
-class OperatorKron(OperatorBinaryOp):
-    """
-    Class representing the tensor product of [`Operators`][oqd_core.interface.analog.operator.Operator]
-
-    Attributes:
-        op1 (Operator): Left hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-        op2 (Operator): Right hand side [`Operator`][oqd_core.interface.analog.operator.Operator]
-    """
-
-    op1: OperatorSubtypes
-    op2: OperatorSubtypes
-
-
-########################################################################################
-
-OperatorSubtypes = Union[
-    PauliI,
-    PauliX,
-    PauliY,
-    PauliZ,
-    Creation,
-    Annihilation,
-    Identity,
-    OperatorAdd,
-    OperatorSub,
-    OperatorMul,
-    OperatorScalarMul,
-    OperatorKron,
-]
-"""
-Alias for the union of concrete Operator subtypes
-"""
+    hamiltonian = gate.hamiltonian
+
+    # 1. Determine n_qreg and check for bosonic modes / consistency
+    counter_rule = QubitCountRule()
+    Post(counter_rule).visit(hamiltonian)
+
+    if not counter_rule.consistent_qreg_size:
+        return None 
+    if counter_rule.n_qmode > 0:
+        return None 
+
+    n_qreg = counter_rule.n_qreg
+    if n_qreg == 0: # No qubit operators found, or inconsistent leading to 0
+        # If an empty Hamiltonian for 0 qubits is valid, return empty matrices.
+        # For now, assume n_qreg > 0 for a meaningful Ising Hamiltonian.
+        return None
+
+    # 2. Initialize coupling matrices
+    pauli_chars = ['X', 'Y', 'Z']
+    coupling_matrices = {f'{p1}{p2}': np.zeros((n_qreg, n_qreg)) 
+                         for p1 in pauli_chars for p2 in pauli_chars}
+
+    # 3. Analyze Hamiltonian structure and populate matrices
+    analyzer = IsingAnalysisRule(n_qreg, coupling_matrices)
+    Post(analyzer).visit(hamiltonian)
+
+    if not analyzer.is_ising_like_overall:
+        return None
+
+    return analyzer.coupling_matrices


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Feature
* **What is the current behavior?** (You can also link to an open issue here)
*   Currently, there is no dedicated functionality within the `oqd_core` analog interface to analyze an `AnalogGate`'s Hamiltonian to determine if it is Ising-like (composed of only qubit registers, weight-2 Pauli strings, and time-independent coefficients) and to extract the corresponding coupling matrices.


* **What is the new behavior (if this is a feature change)?**
*   This PR introduces a new function, `ising_hamiltonian_analysis(gate: AnalogGate)`.
    *   This function inspects the Hamiltonian of the provided `AnalogGate`.
    *   It verifies three main properties:
        1.  The Hamiltonian involves only qubit registers (no bosonic mode operators).
        2.  Each additive term in the Hamiltonian is a weight-2 Pauli string (e.g., `c * X_i @ Z_j`), meaning exactly two Pauli operators in the tensor product are non-identity.
        3.  All coefficients are time-independent (represented by `MathNum`).
    *   If the Hamiltonian is confirmed to be Ising-like, the function returns a dictionary where keys are two-character strings representing Pauli pairs (e.g., 'XX', 'XY', 'XZ') and values are NumPy arrays representing the coupling matrices for those interactions. For 'XX', 'YY', and 'ZZ' terms, symmetry (J_ij = J_ji) is enforced in the matrices.
    *   If the Hamiltonian does not meet these criteria, or if an inconsistency is found (e.g., varying qubit register sizes), the function returns `None`.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 *   No. This PR adds new functionality and does not modify existing interfaces in a breaking way.


* **Other information**:
*   This analysis capability is useful for identifying Hamiltonians that can be mapped to specific quantum hardware, such as trapped-ion systems, by extracting their fundamental interaction terms. It aids in the compilation process from high-level circuit descriptions to hardware-compatible operations.
    *   The implementation uses a `RewriteRule`-based approach to traverse and analyze the operator tree structure of the Hamiltonian
